### PR TITLE
[16.0][IMP] base_edifact: improve method map2odoo_product to take pia segment into account

### DIFF
--- a/base_edifact/README.rst
+++ b/base_edifact/README.rst
@@ -104,6 +104,7 @@ Contributors
 * Rafa Morant <rmorant@albasoft.com> (www.albasoft.com)
 * Marc Poch <mpoch@planetatic.com>
 * Duong (Tran Quoc) <duongtq@trobz.com>
+* Tris Doan <tridm@trobz.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_edifact/models/edifact.py
+++ b/base_edifact/models/edifact.py
@@ -199,14 +199,16 @@ class BasePydifact(models.AbstractModel):
             ['5', ['1276', 'SA', '', '9']]
         SA. Supplier's Article Number
         """
+        res = {}
+        # Set default code based on SA if given
+        # Fallback on SA if no EAN given
+        if pia is not None and pia[1][0]:
+            res["code"] = pia[1][0]
         code = seg[2][0] if len(list(seg)) > 2 else False
         if code:
             field = "code" if seg[2][1] == "SRV" else "barcode"
-            return {field: code}
-        # Fallback on SA if no EAN given
-        if pia is not None and pia[1][0]:
-            return {"code": pia[1][0]}
-        return {}
+            res[field] = code
+        return res
 
     @api.model
     def map2odoo_qty(self, seg):

--- a/base_edifact/readme/CONTRIBUTORS.rst
+++ b/base_edifact/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Rafa Morant <rmorant@albasoft.com> (www.albasoft.com)
 * Marc Poch <mpoch@planetatic.com>
 * Duong (Tran Quoc) <duongtq@trobz.com>
+* Tris Doan <tridm@trobz.com>

--- a/base_edifact/static/description/index.html
+++ b/base_edifact/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -448,12 +449,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Rafa Morant &lt;<a class="reference external" href="mailto:rmorant&#64;albasoft.com">rmorant&#64;albasoft.com</a>&gt; (www.albasoft.com)</li>
 <li>Marc Poch &lt;<a class="reference external" href="mailto:mpoch&#64;planetatic.com">mpoch&#64;planetatic.com</a>&gt;</li>
 <li>Duong (Tran Quoc) &lt;<a class="reference external" href="mailto:duongtq&#64;trobz.com">duongtq&#64;trobz.com</a>&gt;</li>
+<li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
### This change
- Improve `map2odoo_product()` to process pia segment (if provided). The codes is later used to find products in [`business.document.import:_match_product_search() `](https://github.com/OCA/edi/blob/9cd45f58ace990702b5a816f166e51943850f46a/base_business_document_import/models/business_document_import.py#L693)
- Before this change, users cannot import sale order when barcode and product code are both provided in edifact file and product,in Odoo, does not contain barcode.

### Result
1. Import with non-existing code
![user_error](https://github.com/trisdoan/edi/assets/88806544/1602344b-8023-49e1-a571-83c689ad9da1)

3. Import with skipping error
![chatter_log](https://github.com/trisdoan/edi/assets/88806544/2dfa6c2d-88fc-4878-9ff9-d70995f018c9)
